### PR TITLE
Add wfrun prefix to test schema

### DIFF
--- a/test/process_run.yaml
+++ b/test/process_run.yaml
@@ -7,6 +7,7 @@ license: Apache-2.0
 created_by: https://github.com/ResearchObject/workflow-run-crate/graphs/contributors
 prefixes:
   schema: http://schema.org/
+  wfrun: https://w3id.org/ro/terms/workflow-run#
 imports:
   - ./schemaorg_current
   - ./formal_parameter

--- a/test/test_mode.py
+++ b/test/test_mode.py
@@ -11,8 +11,8 @@ def test_mode_file_generation(process_run: str, process_run_sv: SchemaView):
     assert "MediaObject" not in mode_classes, "Schema.org classes should not be included in the mode file"
     for cname, mode_cls in mode.classes.items():
         assert len(mode_cls.inputs) == len(process_run_sv.class_slots(cname))
-        assert mode_cls.id is not None and ":" not in mode_cls.id
+        assert mode_cls.id is not None and "wfrun:" not in mode_cls.id
         for slot in mode_cls.inputs:
-            assert slot.id is not None and ":" not in slot.id
+            assert slot.id is not None and "wfrun:" not in slot.id
             assert slot.help is not None
             assert slot.label is not None


### PR DESCRIPTION
Fixes #7. The logic was already in place, the example schema was just missing the `wfrun` prefix definition.